### PR TITLE
update guile detection

### DIFF
--- a/opcodes/Makefile.in
+++ b/opcodes/Makefile.in
@@ -608,7 +608,7 @@ CLEANFILES = \
 
 CGENDIR = @cgendir@
 CPUDIR = $(srcdir)/../cpu
-CGEN = "`if test -f ../guile/libguile/guile ; then echo ../guile/libguile/guile; else echo guile ; fi` -l ${cgendir}/guile.scm -s"
+CGEN = "`if test -f ../guile/libguile/guile ; then echo ../guile/libguile/guile; else echo \`which 2> /dev/null guile{,-}1.8\` ; fi` -l ${cgendir}/guile.scm -s"
 CGENFLAGS = -v
 CGENDEPS = \
 	$(CGENDIR)/desc.scm $(CGENDIR)/desc-cpu.scm \


### PR DESCRIPTION
some distributions have default guile 2.0 based, which is not
friendly to cgen scripts.

Signed-off-by: Jiri Kastner <jkastner@redhat.com>